### PR TITLE
Run generated hash through md5()

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -43,7 +43,7 @@ class CommentController extends Controller{
             'slug' => ltrim($request->input('slug'), '/'),
             'ip' => $request->getClientIp(),
         );
-        $commentData['token'] = \Hash::make($commentData['comment'] . $commentData['email'] . $commentData['slug']);
+        $commentData['token'] = md5(\Hash::make($commentData['comment'] . $commentData['email'] . $commentData['slug']));
         $comment = Comment::create($commentData);
 
         $commentData['created_at'] = $comment->created_at->toDateTimeString();


### PR DESCRIPTION
The hash generated by \Hash::make() can contain special characters that
don't translate well when visited in browser, and this can make it
difficult/impossible to delete a comment via the URL. This commit takes
the generated hash and runs it through md5() to generate an alphanumeric
string that your browser won't have trouble processing!
