### PR TITLE
Issue #106: savaslabs email field

### DIFF
--- a/source/app/Comment.php
+++ b/source/app/Comment.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Comment extends Model
 {
-    protected $fillable = ['slug', 'comment', 'name', 'email', 'ip', 'token'];
+    protected $fillable = ['slug', 'comment', 'name', 'email', 'ip', 'token', 'savasian'];
 
     protected $hidden = ['token', 'email', 'ip'];
 

--- a/source/app/Http/Controllers/CommentController.php
+++ b/source/app/Http/Controllers/CommentController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use App\Helpers\CommentHelpers;
 use App\Helpers\SlackHelpers;
 
-class CommentController extends Controller{
+class CommentController extends Controller {
 
     public function index() {
         $comments = Comment::all();
@@ -44,6 +44,10 @@ class CommentController extends Controller{
             'slug' => ltrim($request->input('slug'), '/'),
             'ip' => $request->getClientIp(),
         );
+
+        if (preg_match('@savaslabs.com$', $commentData['email']) === 1) {
+          $commentData['savasian'] = 1;
+        }
 
         $commentData['token'] = md5(\Hash::make($commentData['comment'] . $commentData['email'] . $commentData['slug']));
         $comment = Comment::create($commentData);

--- a/source/app/Http/Controllers/CommentController.php
+++ b/source/app/Http/Controllers/CommentController.php
@@ -45,7 +45,7 @@ class CommentController extends Controller {
             'ip' => $request->getClientIp(),
         );
 
-        if (preg_match('@savaslabs.com$', $commentData['email']) === 1) {
+        if (preg_match('/@savaslabs.com$/', $commentData['email']) === 1) {
           $commentData['savasian'] = 1;
         }
 

--- a/source/database/migrations/2016_08_24_174517_add_savasian_field.php
+++ b/source/database/migrations/2016_08_24_174517_add_savasian_field.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 class AddSavasianField extends Migration {
 
@@ -15,6 +16,10 @@ class AddSavasianField extends Migration {
     Schema::table('comments', function ($table) {
       $table->boolean('savasian')->default(FALSE);
     });
+
+    DB::table('comments')
+      ->where('email', 'like', '%@savaslabs.com')
+      ->update(['savasian' => 1]);
 	}
 
 	/**

--- a/source/database/migrations/2016_08_24_174517_add_savasian_field.php
+++ b/source/database/migrations/2016_08_24_174517_add_savasian_field.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSavasianField extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+    Schema::table('comments', function ($table) {
+      $table->boolean('savasian')->default(FALSE);
+    });
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		//
+	}
+
+}

--- a/source/tests/CommentTest.php
+++ b/source/tests/CommentTest.php
@@ -153,4 +153,22 @@ class CommentTest extends TestCase
         $this->assertResponseStatus(200);
     }
 
+  /**
+   * Test that Savasian field is set to 1 when comment email is @savasalabs.com.
+   */
+  public function testApiSavasianComment() {
+    $comment = array(
+      'comment' => 'Comment to delete',
+      'name' => 'Someone soon to be forgotten',
+      'email' => 'comment@savaslabs.com',
+      'ip' => '127.0.0.1',
+      'nocaptcha' => 'owl',
+      'slug' => '2015/04/27/durham-restaurant-time-machine.html',
+    );
+    $result = $this->call('POST', '/api/comments/new', $comment);
+    $data = json_decode($result->getContent(), true);
+    $this->assertResponseStatus(200);
+    $this->assertEquals($data['data'][0]['savasian'], "1");
+  }
+
 }


### PR DESCRIPTION
Pulled this off `on hold` while I was waiting to get started on the Redmine/Sumac issues. This PR adds a `savasian` field to the comments table and sets that field to 1 when email address on a new comment is `@savaslabs.com`.

It also supposedly migrates existing comments, but we'll need to test that on a copy of the production DB before deploying.

To merge after #9
