### PR TITLE
Issue #5021: Expose email hash.

### DIFF
--- a/source/app/Comment.php
+++ b/source/app/Comment.php
@@ -11,7 +11,7 @@ class Comment extends Model
 {
     protected $fillable = ['slug', 'comment', 'name', 'email', 'ip', 'token', 'savasian'];
 
-    protected $hidden = ['token', 'email', 'ip'];
+    protected $hidden = ['token', 'ip'];
 
     public function getCommentAttribute($value)
     {
@@ -30,7 +30,7 @@ class Comment extends Model
 
     public function getEmailAttribute($value)
     {
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        return md5(trim(htmlspecialchars($value, ENT_QUOTES, 'UTF-8')));
     }
 
     public function getIpAttribute($value)

--- a/source/app/Comment.php
+++ b/source/app/Comment.php
@@ -30,7 +30,7 @@ class Comment extends Model
 
     public function getEmailAttribute($value)
     {
-        return md5(trim(htmlspecialchars($value, ENT_QUOTES, 'UTF-8')));
+        return md5(strtolower(trim(htmlspecialchars($value, ENT_QUOTES, 'UTF-8'))));
     }
 
     public function getIpAttribute($value)


### PR DESCRIPTION
Exposes email hash. Hash is needed for the gravatar pulls.

the output of a comment via http://local.comments.savaslabs.com/api/comments should look like something like this, where email is an md5 hash
```
{"id":"5","slug":"2017\/11\/08\/cost-of-drupal-7.html","comment":"Test comment ","name":"Oksana Cyrwus","email":"c1afc40a295270e9827913fdfa80f864","created_at":"2018-02-02 20:46:06","updated_at":"2018-02-02 20:46:06","savasian":"0"}],"message":""}
```